### PR TITLE
Add item_id to pubsub messages

### DIFF
--- a/cli/iotexetl/streaming/item_exporter_creator.py
+++ b/cli/iotexetl/streaming/item_exporter_creator.py
@@ -27,12 +27,14 @@ def create_item_exporter(output):
     item_exporter_type = determine_item_exporter_type(output)
     if item_exporter_type == ItemExporterType.PUBSUB:
         from blockchainetl_common.jobs.exporters.google_pubsub_item_exporter import GooglePubSubItemExporter
-        item_exporter = GooglePubSubItemExporter(item_type_to_topic_mapping={
-            'block': output + '.blocks',
-            'action': output + '.actions',
-            'log': output + '.logs',
-            'transaction_log': output + '.transaction_logs',
-        })
+        item_exporter = GooglePubSubItemExporter(
+            item_type_to_topic_mapping={
+                'block': output + '.blocks',
+                'action': output + '.actions',
+                'log': output + '.logs',
+                'transaction_log': output + '.transaction_logs',
+            },
+            message_attributes=('item_id',))
     elif item_exporter_type == ItemExporterType.CONSOLE:
         item_exporter = ConsoleItemExporter()
     else:


### PR DESCRIPTION
The PubSubItemExporter is missing the config for including item_id attribute in the messages. This causes Dataflow job to publish duplicate messages sometimes.

The fix is to add the missing configuration option to PubSubItemExporter.